### PR TITLE
feat(kt-215) Refactor result events and add status enum

### DIFF
--- a/common/enums/status.go
+++ b/common/enums/status.go
@@ -1,0 +1,38 @@
+package enums
+
+import "fmt"
+
+// ComponentStatus represents the status of a scan Service
+type ServiceStatus int
+
+const (
+	StatusPending    ServiceStatus = iota
+	StatusInProgress               // The service is currently running.
+	StatusCompleted                // The service completed successfully.
+	StatusFailed                   // The service failed due to an error.
+	StatusCancelled                // The service was cancelled before completion.
+)
+
+var statusStrings = map[ServiceStatus]string{
+	StatusPending:    "Pending",
+	StatusInProgress: "InProgress",
+	StatusCompleted:  "Completed",
+	StatusFailed:     "Failed",
+	StatusCancelled:  "Cancelled",
+}
+
+func (ss ServiceStatus) String() string {
+	if str, exists := statusStrings[ss]; exists {
+		return str
+	}
+	return "Unknown"
+}
+
+func ParseServiceStatus(status string) (ServiceStatus, error) {
+	for k, v := range statusStrings {
+		if v == status {
+			return k, nil
+		}
+	}
+	return -1, fmt.Errorf("invalid ServiceStatus: %s", status)
+}

--- a/common/events/events.go
+++ b/common/events/events.go
@@ -25,6 +25,22 @@ type Target struct {
 	Type TargetType `json:"type"`
 }
 
+type BaseEvent struct {
+	// ScanID is the unique ideantifier of the scan
+	ScanID string `json:"scan_id"`
+
+	// Timestamp is the Unix timestamp when the scan started
+	Timestamp int64 `json:"timestamp"`
+
+	// Include error details if applicable
+	Error *EventError `json:"error,omitempty"`
+}
+
+type EventError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 // ScanStartedEvent represents the payload for a scan initiation event.
 // This event signals that a scan has begun for a specific target.
 type ScanStartedEvent struct {
@@ -41,55 +57,38 @@ type ScanStartedEvent struct {
 // DNSLookupEvent represents the payload of a DNSLookup operation.
 // This event provides details about the DNS information gathered for scan targets.
 type DNSLookupEvent struct {
-	// ScanID is the unique identifier of the scan associated with this event.
-	ScanID string `json:"scan_id"`
+	BaseEvent
 
 	// Results contains the DNS lookup results for the target.
 	Result []results.TargetResult `json:"results"`
-
-	// Timestamp is the Unix timestamp when the scan started
-	Timestamp int64 `json:"timestamp"`
 }
 
 // WhoIsEvent represents the payload of a WhoIs lookup operation.
 // This event provides details about the WhoIs information gathered for scan targets.
 type WhoIsEvent struct {
-	// ScanID is the unique identifier of the scan associated with this event.
-	ScanID string `json:"scan_id"`
+	BaseEvent
 
 	// Results contains the WhoIs lookup results for the target.
 	Results []results.TargetResult `json:"results"`
-
-	// Timestamp is the Unix timestamp when the scan started
-	Timestamp int64 `json:"timestamp"`
 }
 
 // HarvesterEvent represents the payload of a Harvester scan operation.
 // This event provides details about the Harvester information gathered for scan targets.
 type HarvesterEvent struct {
-	// ScanID is the unique identifier of the scan associated with this event.
-	ScanID string `json:"scan_id"`
+	BaseEvent
 
 	// TargetResult contains the WhoIs lookup results for the target.
 	Results []results.TargetResult `json:"results"`
-
-	// Timestamp is the Unix timestamp when the scan started
-	Timestamp int64 `json:"timestamp"`
 }
 
 // NmapEvent represents the payload of a Harvester scan operation.
 // This event provides details about the Harvester information gathered for scan targets.
 type NmapEvent struct {
-	// ScanID is the unique identifier of the scan associated with this event.
-	ScanID string `json:"scan_id"`
+	BaseEvent
 
 	// TargetResult contains the WhoIs lookup results for the target.
 	Results []results.TargetResult `json:"results"`
-
-	// Timestamp is the Unix timestamp when the scan started
-	Timestamp int64 `json:"timestamp"`
 }
-
 
 func (e *ScanStartedEvent) GetDomainValues() []string {
 	domains := make([]string, 0)

--- a/common/events/events.go
+++ b/common/events/events.go
@@ -60,7 +60,7 @@ type DNSLookupEvent struct {
 	BaseEvent
 
 	// Results contains the DNS lookup results for the target.
-	Result []results.TargetResult `json:"results"`
+	Results []results.TargetResult `json:"results"`
 }
 
 // WhoIsEvent represents the payload of a WhoIs lookup operation.

--- a/common/results/status.go
+++ b/common/results/status.go
@@ -1,0 +1,17 @@
+package results
+
+import "github.com/kptm-tools/common/common/enums"
+
+type ScanStatus struct {
+	// ScanID is the unique ideantifier of the scan
+	ScanID string
+
+	// Status of the overall scan
+	Status string
+
+	// Status of each individual service in the scan
+	ServicesStatus map[ServiceName]enums.ServiceStatus
+
+	// Error details of each service in the scan
+	ErrorDetail map[ServiceName]string
+}


### PR DESCRIPTION
* Refactor result events to include errors somewhere

* Add status enum and `ScanStatus` struct which could be used in `core-service` for building a cohesive ScanStatus. The `ServiceStatus` enum attribute could be written from each microservice and read by `core-service`, but I'm unsure if `common/results/status.go` is the right way for `core-service` to handle a Scan easily while aggregating events. 

@cristianoCatolico Perhaps we could mix this somehow with [Core-Service Domain Scan](https://github.com/kptm-tools/core-service/blob/dev/pkg/domain/scan.go) and leave that implementation here in the common package? One thing I failed to mention is that `ScanStatus` is for a single `Target/Host`, so maybe there's some tweaking to be done there too.