### PR TITLE
feat(Weakness): Add WeaknessNoInfo enum

### DIFF
--- a/common/pkg/enums/weakness.go
+++ b/common/pkg/enums/weakness.go
@@ -14,6 +14,7 @@ const (
 	WeaknessInsecureDesign
 	WeaknessSecurityMisconfiguration
 	WeaknessOther
+	WeaknessNoInfo
 )
 
 var weaknessStrings = map[WeaknessType]string{
@@ -28,6 +29,7 @@ var weaknessStrings = map[WeaknessType]string{
 	WeaknessInsecureDesign:                          "Insecure Design",
 	WeaknessSecurityMisconfiguration:                "Security Misconfiguration",
 	WeaknessOther:                                   "Other",
+	WeaknessNoInfo:                                  "No Information Available",
 }
 
 func (w WeaknessType) String() string {


### PR DESCRIPTION
This pull request includes changes to the `common/pkg/enums/weakness.go` file to add a new weakness type and its corresponding string representation.

Changes to `common/pkg/enums/weakness.go`:

* Added `WeaknessNoInfo` to the list of weakness types in the `const` block.
* Added a string representation for `WeaknessNoInfo` in the `weaknessStrings` map.