### PR TITLE
feat(vulnerability): Add helper functions to help parse enum constants

### DIFF
--- a/common/pkg/enums/vulnerability.go
+++ b/common/pkg/enums/vulnerability.go
@@ -11,7 +11,7 @@ const (
 	AccessTypeNetwork         AccessType = "NETWORK"
 	AccessTypeAdjacentNetwork AccessType = "ADJACENT_NETWORK"
 	AccessTypeLocal           AccessType = "LOCAL"
-	AccesTypePhysical         AccessType = "PHYSICAL"
+	AccessTypePhysical        AccessType = "PHYSICAL"
 	AccessTypeUnknown         AccessType = "UNKNOWN"
 )
 
@@ -23,7 +23,7 @@ func (a AccessType) String() string {
 func ParseAccessType(s string, defaultVal AccessType) AccessType {
 	val := AccessType(strings.ToUpper(s)) // Normalize input
 	switch val {
-	case AccessTypeNetwork, AccessTypeAdjacentNetwork, AccessTypeLocal, AccesTypePhysical: // Corrected const name
+	case AccessTypeNetwork, AccessTypeAdjacentNetwork, AccessTypeLocal, AccessTypePhysical:
 		return val
 	default:
 		return defaultVal

--- a/common/pkg/enums/vulnerability.go
+++ b/common/pkg/enums/vulnerability.go
@@ -168,7 +168,7 @@ type ExploitabilityType string
 const (
 	ExploitabilityTypeUnproven       ExploitabilityType = "UNPROVEN"
 	ExploitabilityTypeProofOfConcept ExploitabilityType = "PROOF_OF_CONCEPT"
-	ExploitabilityTypeFunctional     ExploitabilityType = "FUNCIONAL"
+	ExploitabilityTypeFunctional     ExploitabilityType = "FUNCTIONAL"
 	ExploitabilityTypeHigh           ExploitabilityType = "HIGH"
 	ExploitabilityTypeNotDefined     ExploitabilityType = "NOT_DEFINED"
 	ExploitabilityTypeUnknown        ExploitabilityType = "UNKNOWN"

--- a/common/pkg/enums/vulnerability.go
+++ b/common/pkg/enums/vulnerability.go
@@ -48,7 +48,7 @@ func (c ComplexityType) String() string {
 func ParseComplexityType(s string, defaultVal ComplexityType) ComplexityType {
 	val := ComplexityType(strings.ToUpper(s))
 	switch val {
-	case ComplexityTypeLow, ComplexityTypeHigh:
+	case ComplexityTypeLow, ComplexityTypeMedium, ComplexityTypeHigh:
 		return val
 	default:
 		return defaultVal

--- a/common/pkg/enums/vulnerability.go
+++ b/common/pkg/enums/vulnerability.go
@@ -8,55 +8,88 @@ import (
 type AccessType string
 
 const (
-	AccessTypeNetwork         AccessType = "Network"
-	AccessTypeAdjacentNetwork AccessType = "Adjacent Network"
-	AccessTypeLocal           AccessType = "Local"
-	AccesTypePhysical         AccessType = "Physical"
-	AccessTypeUnknown         AccessType = "Unknown"
+	AccessTypeNetwork         AccessType = "NETWORK"
+	AccessTypeAdjacentNetwork AccessType = "ADJACENT_NETWORK"
+	AccessTypeLocal           AccessType = "LOCAL"
+	AccesTypePhysical         AccessType = "PHYSICAL"
+	AccessTypeUnknown         AccessType = "UNKNOWN"
 )
 
 func (a AccessType) String() string {
 	return string(a)
 }
 
+// ParseAccessType converts a string to AccessType
+func ParseAccessType(s string, defaultVal AccessType) AccessType {
+	val := AccessType(strings.ToUpper(s)) // Normalize input
+	switch val {
+	case AccessTypeNetwork, AccessTypeAdjacentNetwork, AccessTypeLocal, AccesTypePhysical: // Corrected const name
+		return val
+	default:
+		return defaultVal
+	}
+}
+
 // ComplexityType represents the attack complexity of a vulnerability
 type ComplexityType string
 
 const (
-	ComplexityTypeLow     ComplexityType = "Low"
-	ComplexityTypeMedium  ComplexityType = "Medium"
-	ComplexityTypeHigh    ComplexityType = "High"
-	ComplexityTypeUnknown ComplexityType = "Unknown"
+	ComplexityTypeLow     ComplexityType = "LOW"
+	ComplexityTypeMedium  ComplexityType = "MEDIUM"
+	ComplexityTypeHigh    ComplexityType = "HIGH"
+	ComplexityTypeUnknown ComplexityType = "UNKNOWN"
 )
 
 func (c ComplexityType) String() string {
 	return string(c)
 }
 
+// ParseComplexityType converts a string to ComplexityType
+func ParseComplexityType(s string, defaultVal ComplexityType) ComplexityType {
+	val := ComplexityType(strings.ToUpper(s))
+	switch val {
+	case ComplexityTypeLow, ComplexityTypeHigh:
+		return val
+	default:
+		return defaultVal
+	}
+}
+
 // PrivilegesRequiredType represents the privileges required to explouit a vulnerability
 type PrivilegesRequiredType string
 
 const (
-	PrivilegesRequiredNone    PrivilegesRequiredType = "None"
-	PrivilegesRequiredLow     PrivilegesRequiredType = "Low"
-	PrivilegesRequiredHigh    PrivilegesRequiredType = "High"
-	PrivilegesRequiredUnknown PrivilegesRequiredType = "Unknown"
+	PrivilegesRequiredNone    PrivilegesRequiredType = "NONE"
+	PrivilegesRequiredLow     PrivilegesRequiredType = "LOW"
+	PrivilegesRequiredHigh    PrivilegesRequiredType = "HIGH"
+	PrivilegesRequiredUnknown PrivilegesRequiredType = "UNKNOWN"
 )
 
 func (p PrivilegesRequiredType) String() string {
 	return string(p)
 }
 
+// ParsePrivilegesRequiredType converts a string to PrivilegesRequiredType.
+func ParsePrivilegesRequiredType(s string, defaultVal PrivilegesRequiredType) PrivilegesRequiredType {
+	val := PrivilegesRequiredType(strings.ToUpper(s))
+	switch val {
+	case PrivilegesRequiredNone, PrivilegesRequiredLow, PrivilegesRequiredHigh:
+		return val
+	default:
+		return defaultVal
+	}
+}
+
 // SeverityType represents the base severity of a vulnerability.
 type SeverityType string
 
 const (
-	SeverityTypeCritical SeverityType = "Critical"
-	SeverityTypeHigh     SeverityType = "High"
-	SeverityTypeMedium   SeverityType = "Medium"
-	SeverityTypeLow      SeverityType = "Low"
-	SeverityTypeNone     SeverityType = "None"
-	SeverityTypeUnknown  SeverityType = "Unknown"
+	SeverityTypeCritical SeverityType = "CRITICAL"
+	SeverityTypeHigh     SeverityType = "HIGH"
+	SeverityTypeMedium   SeverityType = "MEDIUM"
+	SeverityTypeLow      SeverityType = "LOW"
+	SeverityTypeNone     SeverityType = "NONE"
+	SeverityTypeUnknown  SeverityType = "UNKNOWN"
 )
 
 func (s SeverityType) String() string {
@@ -80,20 +113,14 @@ func (s SeverityType) Int() int {
 	}
 }
 
-func StringToSeverityType(s string) SeverityType {
-	switch strings.ToLower(s) {
-	case "critical":
-		return SeverityTypeCritical
-	case "high":
-		return SeverityTypeHigh
-	case "medium":
-		return SeverityTypeMedium
-	case "low":
-		return SeverityTypeLow
-	case "none":
-		return SeverityTypeNone
+// ParseSeverityType converts a string to SeverityType.
+func ParseSeverityType(s string, defaultVal SeverityType) SeverityType {
+	val := SeverityType(strings.ToUpper(s))
+	switch val {
+	case SeverityTypeCritical, SeverityTypeHigh, SeverityTypeMedium, SeverityTypeLow, SeverityTypeNone:
+		return val
 	default:
-		return SeverityTypeUnknown
+		return defaultVal
 	}
 }
 
@@ -101,10 +128,10 @@ func StringToSeverityType(s string) SeverityType {
 type ImpactType string
 
 const (
-	ImpactTypeHigh    ImpactType = "High"
-	ImpactTypeLow     ImpactType = "Low"
-	ImpactTypeNone    ImpactType = "None"
-	ImpactTypeUnknown ImpactType = "Unknown"
+	ImpactTypeHigh    ImpactType = "HIGH"
+	ImpactTypeLow     ImpactType = "LOW"
+	ImpactTypeNone    ImpactType = "NONE"
+	ImpactTypeUnknown ImpactType = "UNKNOWN"
 )
 
 func (i ImpactType) String() string {
@@ -124,31 +151,59 @@ func (i ImpactType) Float64() float64 {
 	}
 }
 
+// ParseImpactType converts a string to ImpactType.
+func ParseImpactType(s string, defaultVal ImpactType) ImpactType {
+	val := ImpactType(strings.ToUpper(s))
+	switch val {
+	case ImpactTypeHigh, ImpactTypeLow, ImpactTypeNone:
+		return val
+	default:
+		return defaultVal
+	}
+}
+
 // ExploitabilityType represents how exploitable the vulnerability is.
 type ExploitabilityType string
 
 const (
-	ExploitabilityTypeUnproven       ExploitabilityType = "Unproven"
-	ExploitabilityTypeProofOfConcept ExploitabilityType = "Proof of Concept"
-	ExploitabilityTypeFunctional     ExploitabilityType = "Functional"
-	ExploitabilityTypeHigh           ExploitabilityType = "High"
-	ExploitabilityTypeUndefined      ExploitabilityType = "Not Defined"
-	ExploitabilityTypeUnknown        ExploitabilityType = "Unknown"
+	ExploitabilityTypeUnproven       ExploitabilityType = "UNPROVEN"
+	ExploitabilityTypeProofOfConcept ExploitabilityType = "PROOF_OF_CONCEPT"
+	ExploitabilityTypeFunctional     ExploitabilityType = "FUNCIONAL"
+	ExploitabilityTypeHigh           ExploitabilityType = "HIGH"
+	ExploitabilityTypeNotDefined     ExploitabilityType = "NOT_DEFINED"
+	ExploitabilityTypeUnknown        ExploitabilityType = "UNKNOWN"
 )
 
 func (e ExploitabilityType) String() string {
 	return string(e)
 }
 
+// ParseExploitabilityType converts a string to ExploitabilityType.
+func ParseExploitabilityType(s string, defaultVal ExploitabilityType) ExploitabilityType {
+	val := ExploitabilityType(strings.ToUpper(strings.ReplaceAll(s, " ", "_"))) // Normalize common inputs
+	switch val {
+	case ExploitabilityTypeUnproven, ExploitabilityTypeProofOfConcept, ExploitabilityTypeFunctional, ExploitabilityTypeHigh, ExploitabilityTypeNotDefined:
+		return val
+	default:
+		// Try direct match if normalization failed
+		directMatch := ExploitabilityType(s)
+		switch directMatch {
+		case ExploitabilityTypeUnproven, ExploitabilityTypeProofOfConcept, ExploitabilityTypeFunctional, ExploitabilityTypeHigh, ExploitabilityTypeNotDefined:
+			return directMatch
+		}
+		return defaultVal
+	}
+}
+
 // LikelyhoodType refers to the probability that a vulnerability will be exploited.
 type LikelyhoodType string
 
 const (
-	LikelyhoodTypeVeryHigh LikelyhoodType = "Very High"
-	LikelyhoodTypeHigh     LikelyhoodType = "High"
-	LikelyhoodTypeMedium   LikelyhoodType = "Medium"
-	LikelyhoodTypeLow      LikelyhoodType = "Low"
-	LikelyhoodTypeUnknown  LikelyhoodType = "Unknown"
+	LikelyhoodTypeVeryHigh LikelyhoodType = "VERY_HIGH"
+	LikelyhoodTypeHigh     LikelyhoodType = "HIGH"
+	LikelyhoodTypeMedium   LikelyhoodType = "MEDIUM"
+	LikelyhoodTypeLow      LikelyhoodType = "LOW"
+	LikelyhoodTypeUnknown  LikelyhoodType = "UNKNOWN"
 )
 
 func (l LikelyhoodType) String() string {
@@ -167,6 +222,16 @@ func (l LikelyhoodType) Float64() float64 {
 		return 0.2
 	default:
 		return 0.0
+	}
+}
+
+func ParseLikelyhoodType(s string, defaultVal LikelyhoodType) LikelyhoodType {
+	val := LikelyhoodType(strings.ToUpper(strings.ReplaceAll(s, " ", "_")))
+	switch val {
+	case LikelyhoodTypeVeryHigh, LikelyhoodTypeHigh, LikelyhoodTypeMedium, LikelyhoodTypeLow:
+		return val
+	default:
+		return defaultVal
 	}
 }
 


### PR DESCRIPTION
This pull request refactors the `vulnerability.go` file to standardize the representation of enumeration values and introduces parsing functions for each type. The most significant changes include converting enumeration values to uppercase for consistency, adding normalization logic to parsing functions, and correcting naming inconsistencies.

### Enumeration Value Standardization:
* Changed all enumeration values (`AccessType`, `ComplexityType`, `PrivilegesRequiredType`, `SeverityType`, `ImpactType`, `ExploitabilityType`, `LikelyhoodType`) to uppercase for consistency across the codebase. [[1]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfL11-R92) [[2]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfL83-R134) [[3]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfR154-R206) [[4]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfR228-R237)

### Parsing Function Additions:
* Added `ParseAccessType`, `ParseComplexityType`, `ParsePrivilegesRequiredType`, `ParseSeverityType`, `ParseImpactType`, `ParseExploitabilityType`, and `ParseLikelyhoodType` functions to convert strings into their respective types, with normalization logic to handle common input formats. [[1]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfL11-R92) [[2]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfL83-R134) [[3]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfR154-R206) [[4]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfR228-R237)

### Bug Fixes:
* Corrected naming inconsistencies, such as `AccesTypePhysical` to `AccessTypePhysical` and `ExploitabilityTypeUndefined` to `ExploitabilityTypeNotDefined`. [[1]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfL11-R92) [[2]](diffhunk://#diff-044ea3ae5c236f6e45c4575f8c6ab917fb2f28bbfcf01df91fc995f7c6c8edcfR154-R206)